### PR TITLE
feat: [Issue #36] 测试场 (TestChamber) 和图鉴 (Codex) 迁移至 2.5D 渲染

### DIFF
--- a/godot_project/scenes/test_chamber.tscn
+++ b/godot_project/scenes/test_chamber.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://test_chamber_001"]
+[gd_scene load_steps=14 format=3 uid="uid://test_chamber_001"]
 
 [ext_resource type="Script" path="res://scripts/scenes/test_chamber.gd" id="1_test_chamber"]
 [ext_resource type="Script" path="res://scripts/entities/player.gd" id="2_player"]
@@ -7,6 +7,12 @@
 [ext_resource type="Script" path="res://scripts/ui/sequencer_ui.gd" id="5_sequencer"]
 [ext_resource type="Script" path="res://scripts/ui/debug_panel.gd" id="6_debug"]
 [ext_resource type="Script" path="res://scripts/ui/dps_overlay.gd" id="7_dps"]
+[ext_resource type="Script" path="res://scripts/entities/player_visual_enhanced.gd" id="8_player_visual"]
+[ext_resource type="Script" path="res://scripts/systems/render_bridge_3d.gd" id="9_render_bridge"]
+[ext_resource type="Script" path="res://scripts/systems/chapter_manager.gd" id="10_chapter"]
+[ext_resource type="Script" path="res://scripts/systems/spell_visual_manager.gd" id="11_spell_visual"]
+[ext_resource type="Script" path="res://scripts/systems/death_vfx_manager.gd" id="12_death_vfx"]
+[ext_resource type="Script" path="res://scripts/systems/damage_number_manager.gd" id="13_dmg_num"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_player"]
 radius = 12.0
@@ -23,9 +29,8 @@ script = ExtResource("1_test_chamber")
 position = Vector2(1500, 1500)
 script = ExtResource("2_player")
 
-[node name="PlayerVisual" type="Polygon2D" parent="Player"]
-color = Color(0, 0.9, 0.7, 1)
-polygon = PackedVector2Array(-12, 0, -6, -10, 6, -10, 12, 0, 6, 10, -6, 10)
+[node name="PlayerVisualEnhanced" type="Node2D" parent="Player"]
+script = ExtResource("8_player_visual")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Player"]
 shape = SubResource("CircleShape2D_player")
@@ -48,6 +53,21 @@ position_smoothing_speed = 5.0
 script = ExtResource("3_projectile")
 
 [node name="MultiMeshInstance2D" type="MultiMeshInstance2D" parent="ProjectileManager"]
+
+[node name="ChapterManager" type="Node" parent="."]
+script = ExtResource("10_chapter")
+
+[node name="SpellVisualManager" type="Node2D" parent="."]
+script = ExtResource("11_spell_visual")
+
+[node name="DeathVfxManager" type="Node2D" parent="."]
+script = ExtResource("12_death_vfx")
+
+[node name="DamageNumberManager" type="Node2D" parent="."]
+script = ExtResource("13_dmg_num")
+
+[node name="RenderBridge3D" type="Node" parent="."]
+script = ExtResource("9_render_bridge")
 
 [node name="HUD" type="CanvasLayer" parent="."]
 layer = 10


### PR DESCRIPTION
## 概述

修复 Issue #36：测试场 (TestChamber) 和图鉴 (Codex) 仍使用 2D 渲染，需迁移至 2.5D。

## 修改文件

| 文件 | 变更说明 |
|------|----------|
| `scenes/test_chamber.tscn` | 新增 RenderBridge3D、PlayerVisualEnhanced、ChapterManager 等节点 |
| `scripts/scenes/test_chamber.gd` | v2.0 重写：集成 2.5D 渲染桥接、地面 Shader、敌人 3D 代理、章节视觉切换 |
| `scripts/ui/codex_ui.gd` | v5.0 升级：演示区域 2.5D 渲染、敌人 3D 预览、背景 3D 氛围效果 |

## 测试场 (TestChamber) v2.0

- **RenderBridge3D 集成**：摄像机跟随、玩家 3D 代理创建、弹幕数据同步
- **地面 Shader**：pulsing_grid.gdshader 脉冲网格 + 玩家位置波纹
- **敌人 3D 代理**：精英独立代理（带光源 + 几何体）/ 普通 MultiMesh 批量渲染
- **章节视觉切换**：F11 循环切换 7 个章节主题，更新 3D 光源颜色
- **3D 层开关**：F12 切换 3D 渲染层（性能调试）
- **死亡特效**：敌人击杀时在 3D 层生成爆发粒子

## 图鉴 (Codex) v5.0

- **法术演示 2.5D 升级**：SubViewport 内嵌 3D 渲染管线（Glow/Bloom + 光照）
  - 2D 弹体层 + 3D 渲染叠加层的分层架构
  - 弹体 3D 代理：发光球体 + 点光源 + 拖尾粒子
  - 和弦爆发粒子 + Glow 脉冲
- **敌人 3D 预览**：第三卷条目新增独立 SubViewport 渲染
  - Boss/精英/普通使用不同几何体和发光强度
  - 模型自动旋转展示 + 粒子效果
- **背景 3D 氛围**：星尘粒子 + Glow/Bloom 后处理

## 设计原则

- 2D 物理和碰撞系统完全保留，不做任何迁移
- 3D 层仅负责渲染增强（Glow/Bloom、真实光照、3D 粒子）
- 与 main_game 的 2.5D 渲染风格完全一致
- 所有现有的 2D 脚本无需修改即可运行

Closes #36