### PR TITLE
fix: 修复 shader 引用审计问题

### DIFF
--- a/godot_project/scenes/enemies/enemy_screech.tscn
+++ b/godot_project/scenes/enemies/enemy_screech.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://screech_enemy_001"]
+[gd_scene load_steps=5 format=3 uid="uid://screech_enemy_001"]
 
 [ext_resource type="Script" path="res://scripts/entities/enemies/enemy_screech.gd" id="1_screech"]
 [ext_resource type="Shader" path="res://shaders/enemy_screech_glitch.gdshader" id="2_screech_glitch"]

--- a/godot_project/scenes/enemies/enemy_static.tscn
+++ b/godot_project/scenes/enemies/enemy_static.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://static_enemy_001"]
+[gd_scene load_steps=6 format=3 uid="uid://static_enemy_001"]
 
 [ext_resource type="Script" path="res://scripts/entities/enemies/enemy_static.gd" id="1_static"]
 [ext_resource type="Shader" path="res://shaders/enemy_static_glitch.gdshader" id="2_glitch"]
@@ -43,7 +43,6 @@ polygon_irregularity = 0.4
 [node name="EnemyVisual" type="Polygon2D" parent="."]
 material = SubResource("ShaderMaterial_glitch")
 color = Color(1, 0.2, 0.3, 1)
-# The polygon is now generated dynamically in the script
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_body")

--- a/godot_project/scenes/enemies/enemy_wall.tscn
+++ b/godot_project/scenes/enemies/enemy_wall.tscn
@@ -1,4 +1,4 @@
-# [gd_scene load_steps=8 format=3 uid="uid://wall_enemy_001"]
+[gd_scene load_steps=9 format=3 uid="uid://wall_enemy_001"]
 
 [ext_resource type="Script" path="res://scripts/entities/enemies/enemy_wall.gd" id="1_wall"]
 [ext_resource type="Shader" path="res://shaders/wall_eq_spectrum.gdshader" id="2_eq_spectrum"]
@@ -61,7 +61,7 @@ polygon = PackedVector2Array(-24, -20, -8, -26, 8, -26, 24, -20, 26, -6, 26, 6, 
 
 [node name="ShieldVisual" type="Polygon2D" parent="."]
 material = SubResource("ShaderMaterial_honeycomb")
-polygon = PackedVector2Array(-28, -23, -9, -30, 9, -30, 28, -23, 30, -7, 30, 7, 28, 23, 9, 30, -9, 30, -28, 23, -30, 7, -30, -7) # Slightly larger polygon for shield
+polygon = PackedVector2Array(-28, -23, -9, -30, 9, -30, 28, -23, 30, -7, 30, 7, 28, 23, 9, 30, -9, 30, -28, 23, -30, 7, -30, -7)
 
 [node name="CracksVisual" type="Polygon2D" parent="."]
 visible = false
@@ -81,4 +81,4 @@ collision_layer = 2
 collision_mask = 1
 
 [node name="DamageShape" type="CollisionShape2D" parent="DamageArea"]
-shape = SubResource("CircleShape2D_body") # Use same shape as body for simplicity
+shape = SubResource("CircleShape2D_body")

--- a/godot_project/shaders/enemy_glitch.gdshader
+++ b/godot_project/shaders/enemy_glitch.gdshader
@@ -10,6 +10,7 @@ uniform float hp_ratio : hint_range(0.0, 1.0) = 1.0;
 uniform float beat_energy : hint_range(0.0, 1.0) = 0.0;
 uniform float is_stunned : hint_range(0.0, 1.0) = 0.0;
 uniform vec4 base_tint : source_color = vec4(1.0, 0.2, 0.3, 1.0);
+uniform vec4 glitch_color : source_color = vec4(1.0, 0.0, 0.67, 1.0);
 
 // === 故障效果参数 ===
 uniform float scanline_density : hint_range(10.0, 200.0) = 80.0;
@@ -100,6 +101,7 @@ void fragment() {
 
     // === 应用基础色调 ===
     color.rgb *= base_tint.rgb;
+    color.rgb = mix(color.rgb, glitch_color.rgb, glitch_intensity * 0.3);
 
     COLOR = color;
 }

--- a/godot_project/shaders/enemy_pulse_led.gdshader
+++ b/godot_project/shaders/enemy_pulse_led.gdshader
@@ -9,6 +9,7 @@ uniform float hp_ratio : hint_range(0.0, 1.0) = 1.0;
 uniform float beat_energy : hint_range(0.0, 1.0) = 0.0;
 uniform float is_stunned : hint_range(0.0, 1.0) = 0.0;
 uniform vec4 base_tint : source_color = vec4(0.2, 0.6, 1.0, 1.0);
+uniform vec4 glitch_color : source_color = vec4(1.0, 0.0, 0.67, 1.0);
 
 // === 故障效果细节参数 (从 enemy_glitch 继承) ===
 uniform float scanline_density : hint_range(10.0, 200.0) = 80.0;
@@ -110,6 +111,7 @@ void fragment() {
 
     // 应用基础色调
     color.rgb *= base_tint.rgb;
+    color.rgb = mix(color.rgb, glitch_color.rgb, glitch_intensity * 0.3);
 
     COLOR = color;
 }

--- a/godot_project/shaders/enemy_screech_glitch.gdshader
+++ b/godot_project/shaders/enemy_screech_glitch.gdshader
@@ -11,6 +11,7 @@ uniform float hp_ratio : hint_range(0.0, 1.0) = 1.0;
 uniform float beat_energy : hint_range(0.0, 1.0) = 0.0;
 uniform float is_stunned : hint_range(0.0, 1.0) = 0.0;
 uniform vec4 base_tint : source_color = vec4(1.0, 0.2, 0.3, 1.0);
+uniform vec4 glitch_color : source_color = vec4(1.0, 0.0, 0.67, 1.0);
 
 // === 故障效果参数 ===
 uniform float scanline_density : hint_range(10.0, 200.0) = 80.0;
@@ -111,6 +112,7 @@ void fragment() {
 
     // === 应用基础色调 ===
     color.rgb *= base_tint.rgb;
+    color.rgb = mix(color.rgb, glitch_color.rgb, glitch_intensity * 0.3);
 
     // === 尖端高亮 ===
     // v_local_pos_y 是从 vertex shader 传来的局部坐标 Y 值

--- a/godot_project/shaders/enemy_static_glitch.gdshader
+++ b/godot_project/shaders/enemy_static_glitch.gdshader
@@ -9,6 +9,7 @@ uniform float hp_ratio : hint_range(0.0, 1.0) = 1.0;
 uniform float beat_energy : hint_range(0.0, 1.0) = 0.0;
 uniform float is_stunned : hint_range(0.0, 1.0) = 0.0;
 uniform vec4 base_tint : source_color = vec4(1.0, 0.2, 0.3, 1.0);
+uniform vec4 glitch_color : source_color = vec4(1.0, 0.0, 0.67, 1.0);
 
 // === 基础效果参数 (从 enemy_glitch 继承) ===
 uniform float scanline_density : hint_range(10.0, 200.0) = 80.0;
@@ -118,6 +119,7 @@ void fragment() {
 
     // === 应用基础色调 ===
     color.rgb *= base_tint.rgb;
+    color.rgb = mix(color.rgb, glitch_color.rgb, glitch_intensity * 0.3);
 
     COLOR = color;
 }

--- a/godot_project/shaders/wall_eq_spectrum.gdshader
+++ b/godot_project/shaders/wall_eq_spectrum.gdshader
@@ -9,6 +9,7 @@ uniform float hp_ratio : hint_range(0.0, 1.0) = 1.0;
 uniform float beat_energy : hint_range(0.0, 1.0) = 0.0;
 uniform float is_stunned : hint_range(0.0, 1.0) = 0.0;
 uniform vec4 base_tint : source_color = vec4(1.0, 0.2, 0.3, 1.0);
+uniform vec4 glitch_color : source_color = vec4(1.0, 0.0, 0.67, 1.0);
 uniform float chromatic_offset : hint_range(0.0, 10.0) = 2.0;
 uniform float pixel_size : hint_range(1.0, 16.0) = 1.0;
 
@@ -59,6 +60,7 @@ void fragment() {
 
     // 组合颜色
     final_color.rgb *= base_tint.rgb; // 应用基础色调
+    color.rgb = mix(color.rgb, glitch_color.rgb, glitch_intensity * 0.3);
     final_color.rgb += emission; // 叠加 EQ 发光效果
 
     // 节拍脉冲


### PR DESCRIPTION
## 修复内容

对 Issue #60-#65 合并后的代码进行全面引用审计，发现并修复以下问题：

### 1. 场景文件格式修复
- **enemy_wall.tscn**: `gd_scene` 头被 `#` 注释掉，导致 Godot 无法正确解析场景
- **enemy_static.tscn**: `load_steps=4` 修正为 `load_steps=6`（2 ext + 3 sub + 1）
- **enemy_screech.tscn**: `load_steps=4` 修正为 `load_steps=5`（2 ext + 2 sub + 1）
- **enemy_wall.tscn**: `load_steps=8` 修正为 `load_steps=9`（4 ext + 4 sub + 1）
- 移除 `.tscn` 文件中不支持的行尾 `#` 注释

### 2. Shader uniform 兼容性修复
- `enemy_visual_enhancer.gd` 会按章节设置 `glitch_color` 参数，但所有 shader 都缺少此 uniform
- 为以下 5 个 shader 添加 `glitch_color` uniform 并在 fragment 中使用：
  - `enemy_static_glitch.gdshader`
  - `enemy_screech_glitch.gdshader`
  - `enemy_pulse_led.gdshader`
  - `wall_eq_spectrum.gdshader`
  - `enemy_glitch.gdshader`（boss 和 silence 场景使用）

### 审计确认通过项
- 所有 `.tscn` 中的 shader_parameter 与对应 shader 的 uniform 完全匹配
- 所有脚本中 `load()`/`preload()` 引用的 shader 文件均存在
- 所有 `@onready` 节点引用与场景中的节点名一致
- 所有 shader 均有正确的 `shader_type canvas_item;` 声明
- 所有场景引用的脚本路径正确