### PR TITLE
[P1] 修复悬空信号 dissonance_corrosion_triggered 和 spatial_params_changed

### DIFF
--- a/godot_project/scripts/autoload/spellcraft_system.gd
+++ b/godot_project/scripts/autoload/spellcraft_system.gd
@@ -821,6 +821,8 @@ func _cast_chord(chord_result: Dictionary) -> void:
 		ModeSystem.on_dissonance_applied(dissonance)
 		# ★ 关键交互：不和谐法术缓解单调值（因为引入了变化）
 		FatigueManager.reduce_monotony_from_dissonance(dissonance)
+		# ★ 发射不和谐腐蚀信号（供视觉特效管理器监听）
+		dissonance_corrosion_triggered.emit({"dissonance": dissonance})
 
 	# 扩展和弦额外疲劳
 	var extra_fatigue: float = MusicData.EXTENDED_CHORD_FATIGUE.get(chord_type, 0.0)

--- a/godot_project/scripts/systems/spatial_audio_controller.gd
+++ b/godot_project/scripts/systems/spatial_audio_controller.gd
@@ -179,6 +179,9 @@ func _update_spatial_params() -> void:
 
 	# 5. 计算声相值（基于屏幕相对位置）
 	_current_pan = _calculate_pan(enemy_pos, player_pos)
+	
+	# 6. 发射空间参数变化信号（供调试面板和外部系统使用）
+	spatial_params_changed.emit(get_spatial_snapshot())
 
 ## 确定敌人所处的距离区间
 func _calculate_zone(distance: float) -> DistanceZone:


### PR DESCRIPTION
## 概述

本 PR 修复了 Issue #107 中报告的悬空信号问题。

## 修改内容

### 1. spellcraft_system.gd
- 在不和谐和弦施法逻辑中（第 818-825 行）添加了 `dissonance_corrosion_triggered.emit()` 调用
- 当不和谐度 > 2.0 时，在应用伤害和其他效果后发射信号
- 信号携带 `{"dissonance": dissonance}` 数据，供视觉特效管理器使用

### 2. spatial_audio_controller.gd
- 在 `_update_spatial_params()` 函数末尾（第 183-184 行）添加了 `spatial_params_changed.emit()` 调用
- 每次更新空间音频参数后发射信号，携带完整的空间参数快照
- 供调试面板和外部系统监听使用

## 验收标准

- [x] `dissonance_corrosion_triggered` 信号在适当的不和谐和弦施法逻辑中被触发
- [x] `spell_visual_manager.gd` 和 `vfx_manager.gd` 中的视觉特效可以正确响应（信号已连接）
- [x] `spatial_params_changed` 信号在参数更新时被触发

## 关联 Issue

Fixes #107

## 关于 Issue #106

在检查代码时发现，Issue #106 中提到的第 4-7 章章节特色敌人实际上已经在 `enemy_pool` 中了：
- 第4章：`ch4_minuet_dancer` ✅
- 第5章：`ch5_fate_knocker`, `ch5_crescendo_surge`, `ch5_fury_spirit` ✅
- 第6章：`ch6_walking_bass`, `ch6_scat_singer` ✅
- 第7章：`ch7_bitcrusher_worm`, `ch7_glitch_phantom` ✅

建议在 Issue #106 中确认当前代码状态是否符合预期。