### PR TITLE
fix: 修复 UI 重绘性能问题 - 添加可见性检查和条件触发机制

### DIFF
--- a/godot_project/scripts/ui/ammo_ring_hud.gd
+++ b/godot_project/scripts/ui/ammo_ring_hud.gd
@@ -62,6 +62,8 @@ func _ready() -> void:
 		SpellcraftSystem.weapon_switched.connect(_on_weapon_switched)
 
 func _process(delta: float) -> void:
+	if not visible:
+		return
 	_time += delta
 	_beat_progress = GameManager.get_beat_progress() if GameManager.has_method("get_beat_progress") else 0.0
 	_update_ammo_data()

--- a/godot_project/scripts/ui/damage_number.gd
+++ b/godot_project/scripts/ui/damage_number.gd
@@ -82,6 +82,8 @@ func _process(delta: float) -> void:
 
 	# 更新视觉效果
 	_update_visual(progress)
+	# 触发重绘以更新波纹和治疗粒子
+	queue_redraw()
 
 # ============================================================
 # 设置

--- a/godot_project/scripts/ui/dps_overlay.gd
+++ b/godot_project/scripts/ui/dps_overlay.gd
@@ -56,9 +56,9 @@ func _process(delta: float) -> void:
 	if _sample_timer >= SAMPLE_INTERVAL:
 		_sample_timer -= SAMPLE_INTERVAL
 		_record_sample()
-
-	if _draw_panel:
-		_draw_panel.queue_redraw()
+		# 仅在采样更新后触发重绘，避免每帧重绘
+		if _draw_panel:
+			_draw_panel.queue_redraw()
 
 # ============================================================
 # UI 构建

--- a/godot_project/scripts/ui/fatigue_meter.gd
+++ b/godot_project/scripts/ui/fatigue_meter.gd
@@ -62,6 +62,8 @@ func _ready() -> void:
 	_setup_shader()
 
 func _process(delta: float) -> void:
+	if not visible:
+		return
 	_time += delta
 	_display_afi = lerp(_display_afi, _afi, delta * 8.0)
 	_beat_intensity = max(0.0, _beat_intensity - delta * 4.0)

--- a/godot_project/scripts/ui/game_mechanics_panel.gd
+++ b/godot_project/scripts/ui/game_mechanics_panel.gd
@@ -183,6 +183,8 @@ func _ready() -> void:
 	_show_crit = (ModeSystem.current_mode_id == "blues")
 
 func _process(delta: float) -> void:
+	if not visible:
+		return
 	_time += delta
 
 	# 平滑过渡

--- a/godot_project/scripts/ui/hall_of_harmony.gd
+++ b/godot_project/scripts/ui/hall_of_harmony.gd
@@ -107,6 +107,8 @@ func _ready() -> void:
 	queue_redraw()
 
 func _process(delta: float) -> void:
+	if not visible:
+		return
 	_time += delta
 	queue_redraw()
 

--- a/godot_project/scripts/ui/hp_bar.gd
+++ b/godot_project/scripts/ui/hp_bar.gd
@@ -52,6 +52,8 @@ func _ready() -> void:
 	_setup_shader()
 
 func _process(delta: float) -> void:
+	if not visible:
+		return
 	_time += delta
 	_display_ratio = lerp(_display_ratio, _hp_ratio, delta * 5.0)
 

--- a/godot_project/scripts/ui/manual_cast_slot.gd
+++ b/godot_project/scripts/ui/manual_cast_slot.gd
@@ -57,6 +57,8 @@ func _ready() -> void:
 		SpellcraftSystem.manual_slot_updated.connect(_on_slot_updated)
 
 func _process(delta: float) -> void:
+	if not visible:
+		return
 	_time += delta
 	_beat_intensity = max(0.0, _beat_intensity - delta * 4.0)
 

--- a/godot_project/scripts/ui/phase_energy_bar.gd
+++ b/godot_project/scripts/ui/phase_energy_bar.gd
@@ -65,6 +65,8 @@ func _ready() -> void:
 	_init_flow_particles()
 
 func _process(delta: float) -> void:
+	if not visible:
+		return
 	_time += delta
 	_beat_pulse = max(0.0, _beat_pulse - delta * 3.0)
 

--- a/godot_project/scripts/ui/phase_gain_hint.gd
+++ b/godot_project/scripts/ui/phase_gain_hint.gd
@@ -76,8 +76,8 @@ func _ready() -> void:
 func _process(delta: float) -> void:
 	_time += delta
 	_beat_pulse = max(0.0, _beat_pulse - delta * 3.0)
-
-	if _is_visible:
+	# 仅在可见或节拍脉冲衰减时重绘
+	if _is_visible or _beat_pulse > 0.0:
 		queue_redraw()
 
 # ============================================================

--- a/godot_project/scripts/ui/phase_indicator_ui.gd
+++ b/godot_project/scripts/ui/phase_indicator_ui.gd
@@ -91,6 +91,8 @@ func _ready() -> void:
 		gmm.beat_energy_updated.connect(_on_beat_energy_updated)
 
 func _process(delta: float) -> void:
+	if not visible:
+		return
 	_time += delta
 
 	# 节拍脉冲衰减

--- a/godot_project/scripts/ui/rhythm_indicator.gd
+++ b/godot_project/scripts/ui/rhythm_indicator.gd
@@ -67,6 +67,8 @@ func _ready() -> void:
 	_setup_shader()
 
 func _process(delta: float) -> void:
+	if not visible:
+		return
 	_time += delta
 	_beat_interval = 60.0 / max(GameManager.current_bpm, 1.0)
 

--- a/godot_project/scripts/ui/sequencer_ui.gd
+++ b/godot_project/scripts/ui/sequencer_ui.gd
@@ -84,8 +84,13 @@ func _ready() -> void:
 	mouse_filter = Control.MOUSE_FILTER_STOP
 
 func _process(delta: float) -> void:
-	_beat_flash = max(0.0, _beat_flash - delta * 4.0)
-	queue_redraw()
+	if not visible:
+		return
+	if _beat_flash > 0.0:
+		_beat_flash = max(0.0, _beat_flash - delta * 4.0)
+		queue_redraw()
+	else:
+		_beat_flash = 0.0
 
 # ============================================================
 # 绘制

--- a/godot_project/scripts/ui/skill_node.gd
+++ b/godot_project/scripts/ui/skill_node.gd
@@ -60,6 +60,8 @@ func _ready() -> void:
 	set_process(true)
 
 func _process(delta: float) -> void:
+	if not visible:
+		return
 	_time += delta
 
 	# 解锁动画

--- a/godot_project/scripts/ui/spectral_fatigue_indicator.gd
+++ b/godot_project/scripts/ui/spectral_fatigue_indicator.gd
@@ -58,6 +58,8 @@ func _ready() -> void:
 		_fragment_offsets[i] = 0.0
 
 func _process(delta: float) -> void:
+	if not visible:
+		return
 	_time += delta
 	_display_value = lerp(_display_value, _sof_value, delta * 10.0)
 

--- a/godot_project/scripts/ui/spellbook_panel_v3.gd
+++ b/godot_project/scripts/ui/spellbook_panel_v3.gd
@@ -79,10 +79,8 @@ func _ready() -> void:
 	mouse_filter = Control.MOUSE_FILTER_STOP
 	clip_contents = true  # 裁剪超出区域的内容
 
-func _process(_delta: float) -> void:
-	## 仅在可见时刷新
-	if is_visible_in_tree():
-		queue_redraw()
+# 注：重绘已改为事件驱动，仅在数据变化（悬停、滚动、刷新）时调用 queue_redraw()
+# 删除了每帧无条件重绘的 _process 函数
 
 # ============================================================
 # 绘制

--- a/godot_project/scripts/ui/summon_hud.gd
+++ b/godot_project/scripts/ui/summon_hud.gd
@@ -51,6 +51,8 @@ func _ready() -> void:
 	mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 func _process(delta: float) -> void:
+	if not visible:
+		return
 	_time += delta
 	_update_data()
 	_update_animations(delta)


### PR DESCRIPTION
## 问题描述

多个 UI 脚本在 `_process()` 中无条件调用 `queue_redraw()`，导致每帧重绘，造成性能浪费。

## 修复内容

### 1. 添加 `visible` 检查（不可见时跳过整个 `_process`）

以下脚本有持续动画（`_time` 驱动的 sin 波动、lerp 插值等），需要每帧重绘，但添加 `visible` 检查后可避免不可见时的无效重绘：

| 脚本 | 修复方式 |
|------|---------|
| `ammo_ring_hud.gd` | 添加 `if not visible: return` |
| `fatigue_meter.gd` | 添加 `if not visible: return` |
| `hp_bar.gd` | 添加 `if not visible: return` |
| `rhythm_indicator.gd` | 添加 `if not visible: return` |
| `phase_energy_bar.gd` | 添加 `if not visible: return` |
| `phase_indicator_ui.gd` | 添加 `if not visible: return` |
| `game_mechanics_panel.gd` | 添加 `if not visible: return` |
| `spectral_fatigue_indicator.gd` | 添加 `if not visible: return` |
| `manual_cast_slot.gd` | 添加 `if not visible: return` |
| `summon_hud.gd` | 添加 `if not visible: return` |
| `skill_node.gd` | 添加 `if not visible: return` |
| `hall_of_harmony.gd` | 添加 `if not visible: return` |

### 2. 改为条件触发重绘

| 脚本 | 修复方式 |
|------|---------|
| `dps_overlay.gd` | 仅在采样间隔（`SAMPLE_INTERVAL`）到达时触发 `queue_redraw()` |
| `sequencer_ui.gd` | 仅在 `_beat_flash > 0` 时重绘（节拍闪光衰减期间） |
| `phase_gain_hint.gd` | 仅在 `_is_visible` 或 `_beat_pulse > 0` 时重绘 |

### 3. 移除每帧无条件重绘

| 脚本 | 修复方式 |
|------|---------|
| `spellbook_panel_v3.gd` | 删除每帧 `queue_redraw()` 的 `_process` 函数，改为事件驱动（悬停、滚动、刷新时触发） |

### 4. 修复缺失的 `queue_redraw` 调用

| 脚本 | 修复方式 |
|------|---------|
| `damage_number.gd` | 在 `_process` 末尾添加 `queue_redraw()` 以正确更新波纹和治疗粒子动画 |

## 已验证无需修改的脚本

以下脚本已有正确的条件保护：
- `chord_alchemy_panel_v3.gd` - 已有 `_craft_flash > 0` 条件
- `info_panel.gd` - 已有 `UPDATE_INTERVAL` 间隔条件
- `note_inventory_ui.gd` - 已有 `needs_redraw` 脏标记
- `run_results_screen.gd` - 已有 `_is_showing` 保护
- `status_notification.gd` - 已有 `_is_active` 保护
- `theory_breakthrough_popup.gd` - 已有 `_is_active` 保护
- `timbre_wheel_ui.gd` - 已有 `visible` 保护
- `circle_of_fifths_upgrade_v3.gd` - 已有 `_is_visible` 保护
- `meta_progression_visualizer.gd` - 已有 `_is_open` 保护
- `mode_selection_screen.gd` - 已有 `_is_open` 保护

## 关于 _draw() 中的 queue_redraw() 问题

经过代码审查，`test_chamber.gd` 和 `chord_alchemy_panel_v3.gd` 的 `_draw()` 函数中**不存在** `queue_redraw()` 调用，该问题已在之前的版本中修复或描述有误。

关联任务：tsk-836616fd-c34